### PR TITLE
Fix broken buffer allocation in LoopbackStream

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Buffered Streams
-version=1.0.2
+version=1.0.3
 author=Paulo Costa
 maintainer=Paulo Costa <me+arduino@paulo.costa.nom.br>
 sentence=Implementation of Arduino's Stream class which use internal ring buffers to emulate a pair of connected Streams or a Loopback Stream.

--- a/src/LoopbackStream.cpp
+++ b/src/LoopbackStream.cpp
@@ -1,8 +1,8 @@
 #include "LoopbackStream.h"
 
 LoopbackStream::LoopbackStream(uint16_t buffer_size) {
-  this->buffer = malloc(buffer_size);
   this->buffer = (uint8_t*) malloc(buffer_size);
+  this->buffer_size = buffer_size;
   this->pos = 0;
   this->size = 0;
 }


### PR DESCRIPTION
It seems that while fixing issue #1 another error was introduced by accident. The added cast for `malloc` was put on the wrong line and the initialization of `this->buffer_size` was removed completely.

This PR fixes these issues and the project compiles again on EPS8266.