### PR TITLE
added contains method

### DIFF
--- a/src/LoopbackStream.cpp
+++ b/src/LoopbackStream.cpp
@@ -51,6 +51,16 @@ int LoopbackStream::availableForWrite() {
   return buffer_size - size;
 }
 
+bool LoopbackStream::contains(char ch) {
+  for (int i=0; i<size; i++){
+    int p = (pos + i) % buffer_size;
+    if (buffer[p] == ch) {
+      return true;
+    }
+  }
+  return false;
+}
+
 int LoopbackStream::peek() {
   return size == 0 ? -1 : buffer[pos];
 }

--- a/src/LoopbackStream.h
+++ b/src/LoopbackStream.h
@@ -26,6 +26,7 @@ public:
   virtual int availableForWrite(void);
   
   virtual int available();
+  virtual bool contains(char);
   virtual int read();
   virtual int peek();
   virtual void flush();


### PR DESCRIPTION
useful for checking if buffer contains termination character (\n, \x00,...) to use with `readStringUntil` method