### PR TITLE
LoopbackStream: Improve Stream interface compatibility

### DIFF
--- a/src/LoopbackStream.h
+++ b/src/LoopbackStream.h
@@ -30,4 +30,8 @@ public:
   virtual int read();
   virtual int peek();
   virtual void flush();
+
+  virtual ssize_t streamRemaining() { return available(); }
+  virtual bool inputCanTimeout() { return false; }
+  virtual bool outputCanTimeout() { return false; }
 };


### PR DESCRIPTION
To use the loopback stream with the ESP8266 Web Server interface, I needed to make `streamRemaining()` return the number of characters available in the stream.

I've also added overrides for the CanTimeout methods, as IO to this type of stream will never block.